### PR TITLE
Updates to work PureScript 0.10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /output/
 /.psci*
 /src/.webpack.js
+/.psc-ide-port

--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ Using a type class allows us to interpret our routes in different ways:
 - As an actual web service
 - As documentation, including an automatically-generated _API tester_.
 
-See the [test project](test/Main.purs) for a worked example.
+See the [test project](test/Main.purs) for a worked example.  You can run the test
+server by running `pulp test` in project root.

--- a/bower.json
+++ b/bower.json
@@ -10,16 +10,18 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-foreign": "~0.7.0",
-    "purescript-globals": "~0.2.1",
-    "purescript-node-http": "~0.1.2",
-    "purescript-node-url": "git@github.com:purescript-node/purescript-node-url.git#~0.1.1",
-    "purescript-refs": "~0.2.0",
-    "purescript-smolder": "~3.0.1"
+    "purescript-foreign": "^3.1.0",
+    "purescript-globals": "^2.0.0",
+    "purescript-node-http": "^3.0.1",
+    "purescript-node-url": "^2.0.0",
+    "purescript-refs": "^2.0.0",
+    "purescript-smolder": "^6.0.1",
+    "purescript-control": "^2.0.0",
+    "purescript-eff": "^2.0.0",
+    "purescript-strings": "^2.1.0",
+    "purescript-console": "^2.0.0"
   },
-  "resolutions": {
-    "purescript-strings": "^0.7.0",
-    "purescript-maps": "^0.5.0"
+  "devDependencies": {
+    "purescript-psci-support": "^2.0.0"
   }
 }

--- a/src/REST/Docs.purs
+++ b/src/REST/Docs.purs
@@ -287,8 +287,8 @@ instance endpointDocs :: Endpoint Docs where
                              (pure unit)
   request             = Docs (Document emptyDoc) (pure unit)
   response            = Docs (Document emptyDoc) (pure unit)
-  --jsonRequest         = requestDocs
-  --jsonResponse        = responseDocs
+  jsonRequest         = requestDocs
+  jsonResponse        = responseDocs
   optional            = map Just
   comments s          = Docs (Document (emptyDoc { comments = Just s }))
                              (pure unit)

--- a/src/REST/Docs.purs
+++ b/src/REST/Docs.purs
@@ -11,32 +11,32 @@ module REST.Docs
   , serveDocs
   ) where
 
-import Prelude
+import Prelude (class Semigroup, (<<<), ($), Unit, (<>), class Applicative, pure, bind, unit, compare, not)
 
-import Data.Maybe
-import Data.Tuple
-import Data.Either
-import Data.Monoid
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Tuple (Tuple(..), fst)
+import Data.Either (Either(..))
+import Data.Monoid (class Monoid, mempty)
 import Data.Functor (($>))
 import Data.Function (on)
-import Data.Foldable (Foldable, foldMap, for_, intercalate)
+import Data.Foldable (class Foldable, foldMap, for_, intercalate)
 
-import qualified Data.List as L
+import Data.List as L
 
-import REST.Endpoint
-import REST.Server
-import REST.JSON
+import REST.Endpoint (Comments, Source, Sink, Example, class Endpoint, ServiceError, class HasExample, staticHtmlResponse, asForeign, lit, example, get)
+import REST.Server (Server, serve)
+import REST.JSON (prettyJSON)
 
-import qualified Node.HTTP        as Node
-import qualified Node.URL         as Node
+import Node.HTTP        as Node
+import Node.URL         as Node
 
 import Control.Alt ((<|>))
 import Control.Apply
 import Control.Monad (when)
 import Control.Monad.Eff
 
-import qualified Text.Smolder.HTML                as H
-import qualified Text.Smolder.HTML.Attributes     as A
+import Text.Smolder.HTML                as H
+import Text.Smolder.HTML.Attributes     as A
 import Text.Smolder.Markup (Markup(), text, (!))
 
 -- | The documentation data structure.
@@ -99,7 +99,7 @@ instance monoidDocument :: Monoid Document where
 -- | Render a `Document` as a HTML string.
 -- |
 -- | The base URL for the running service should be provided in the first argument.
-documentToMarkup :: forall any. String -> Docs any -> Markup
+documentToMarkup :: forall a any. String -> Docs any -> Markup a
 documentToMarkup baseURL (Docs (Document d) _) = do
   H.h1 $ text title
   for_ d.comments (H.p <<< text)
@@ -139,11 +139,11 @@ documentToMarkup baseURL (Docs (Document d) _) = do
   routePartToArg (MatchPart arg) = Just arg
   routePartToArg _ = Nothing
 
-  bulletedList :: forall a. L.List a -> (a -> Markup) -> Markup
+  bulletedList :: forall a b. L.List a -> (a -> Markup b) -> Markup b
   bulletedList xs f = H.ul (for_ xs (H.li <<< f))
 
   title :: String
-  title = maybe "" (<> " ") d.method <> route
+  title = maybe "" ((<>) " ") d.method <> route
 
   route :: String
   route = "/" <> intercalate "/" (map fromRoutePart d.route)
@@ -151,12 +151,12 @@ documentToMarkup baseURL (Docs (Document d) _) = do
     fromRoutePart (LiteralPart s) = s
     fromRoutePart (MatchPart (Arg a)) = ":" <> a.key
 
-  renderArg :: Arg -> Markup
+  renderArg :: forall a. Arg -> Markup a
   renderArg (Arg a) = do
     H.code $ text a.key
     text $ " - " <> a.comments
 
-  textBox :: String -> Arg -> Markup
+  textBox :: forall a. String -> Arg -> Markup a
   textBox pfx (Arg a) = do
     H.div ! A.className "form-group" $ do
       H.label $ text a.key
@@ -164,10 +164,10 @@ documentToMarkup baseURL (Docs (Document d) _) = do
 
   cURLCommand :: String
   cURLCommand = intercalate "\\\n    " $ map (intercalate " ") $
-    [ [ ">", "curl" ] ++ foldMap (\m -> [ "-X", m ]) d.method ] ++
-    foldMap (\(Arg a) -> [ [ "-H", "'" ++ a.key ++ ": {" ++ a.key ++ "}'" ] ]) d.headers ++
-    cURLRequestBody ++
-    cURLResponseBody ++
+    [ [ ">", "curl" ] <> foldMap (\m -> [ "-X", m ]) d.method ] <>
+    foldMap (\(Arg a) -> [ [ "-H", "'" <> a.key <> ": {" <> a.key <> "}'" ] ]) d.headers <>
+    cURLRequestBody <>
+    cURLResponseBody <>
     [ [ url ] ]
     where
     cURLRequestBody :: Array (Array String)
@@ -192,7 +192,7 @@ documentToMarkup baseURL (Docs (Document d) _) = do
       renderQuery qs = "?" <> intercalate "\&" (map (\(Arg a) -> a.key <> "={" <> a.key <> "}") qs)
 
   javascriptContent :: String
-  javascriptContent = foldMap (<> "\n") $
+  javascriptContent = foldMap ((<>) "\n") $
     [ "var tester = document.getElementById('tester');"
     , "tester.onsubmit = function() {"
     , "  var xhr = new XMLHttpRequest();"
@@ -206,8 +206,8 @@ documentToMarkup baseURL (Docs (Document d) _) = do
         queryPart <>
         ";"
     , "  xhr.open(tester.method, uri, true);"
-    ] ++
-    foldMap (\(Arg a) -> [ "  xhr.setRequestHeader('" <> a.key <> "', getFormValue('header', '" <> a.key <> "'));" ]) d.headers ++
+    ] <>
+    foldMap (\(Arg a) -> [ "  xhr.setRequestHeader('" <> a.key <> "', getFormValue('header', '" <> a.key <> "'));" ]) d.headers <>
     [ "  xhr.onreadystatechange = function() {"
     , "    if (xhr.readyState == 4) {"
     , "      document.getElementById('tester-response').innerText = xhr.responseText;"
@@ -235,7 +235,7 @@ documentToMarkup baseURL (Docs (Document d) _) = do
     fromQueryArg :: Arg -> String
     fromQueryArg (Arg a) = "'" <> a.key <> "=' + " <> "getFormValue('query', '" <> a.key <> "')"
 
-generateTOC :: L.List Document -> Markup
+generateTOC :: forall a. L.List Document -> Markup a
 generateTOC docs = do
   H.h1 $ text "API Documentation"
   H.ul $ foldMap toListItem $ L.sortBy (compare `on` fst) $ map toTuple docs
@@ -243,12 +243,12 @@ generateTOC docs = do
   toTuple :: Document -> Tuple String String
   toTuple (Document d) = Tuple (routeToText d.method d.route) (routeToHref d.method d.route)
 
-  toListItem :: Tuple String String -> Markup
+  toListItem :: forall a. Tuple String String -> Markup a
   toListItem (Tuple s href) =
     H.li $ H.a ! A.href href $ text s
 
   routeToHref :: Maybe String -> L.List RoutePart -> String
-  routeToHref method = Node.resolve "/" <<< (("/endpoint/" <> fromMaybe "GET" method) <>) <<< foldMap fromRoutePart
+  routeToHref method = Node.resolve "/" <<< ((<>) ("/endpoint/" <> (fromMaybe "GET" method))) <<< foldMap fromRoutePart
     where
     fromRoutePart (LiteralPart s) = "/" <> s
     fromRoutePart (MatchPart _) = "/_"
@@ -287,8 +287,8 @@ instance endpointDocs :: Endpoint Docs where
                              (pure unit)
   request             = Docs (Document emptyDoc) (pure unit)
   response            = Docs (Document emptyDoc) (pure unit)
-  jsonRequest         = requestDocs
-  jsonResponse        = responseDocs
+  --jsonRequest         = requestDocs
+  --jsonResponse        = responseDocs
   optional            = map Just
   comments s          = Docs (Document (emptyDoc { comments = Just s }))
                              (pure unit)
@@ -304,18 +304,18 @@ generateDocs :: forall a. Docs a -> Document
 generateDocs (Docs d _) = d
 
 -- | Serve documentation for a set of `Endpoint` specifications on the specified port.
-serveDocs :: forall f eff any.
+serveDocs :: forall f b eff any.
   (Functor f, Foldable f) =>
   String ->
   f (Docs any) ->
-  (Markup -> Markup) ->
+  (Markup b -> Markup b) ->
   Int ->
   Eff (http :: Node.HTTP | eff) Unit ->
   Eff (http :: Node.HTTP | eff) Unit
-serveDocs baseURL endpoints wrap = serve (L.Cons tocEndpoint (L.toList (map toServer endpoints)))
+serveDocs baseURL endpoints wrap = serve (L.Cons tocEndpoint (L.fromFoldable (map toServer endpoints)))
   where
   toServer :: Docs any -> Server (Eff (http :: Node.HTTP | eff) Unit)
   toServer s@(Docs (Document d) server) = staticHtmlResponse (lit "endpoint" *> lit (fromMaybe "GET" d.method) *> server $> wrap (documentToMarkup baseURL s))
 
   tocEndpoint :: Server (Eff (http :: Node.HTTP | eff) Unit)
-  tocEndpoint = staticHtmlResponse (get $> wrap (generateTOC (map generateDocs (L.toList endpoints))))
+  tocEndpoint = staticHtmlResponse (get $> wrap (generateTOC (map generateDocs (L.fromFoldable endpoints))))

--- a/src/REST/Endpoint.purs
+++ b/src/REST/Endpoint.purs
@@ -16,8 +16,8 @@ module REST.Endpoint
    , header
    , request
    , response
-   --, jsonRequest
-   --, jsonResponse
+   , jsonRequest
+   , jsonResponse
    , optional
    , comments
    , Hint()
@@ -108,8 +108,8 @@ class (Applicative e) <= Endpoint e where
   header       :: String -> Comments -> e String
   request      :: e Node.Request
   response     :: e Node.Response
-  -- jsonRequest  :: forall req eff. (HasExample req) => e (Source eff (Either ServiceError req))
-  -- jsonResponse :: forall res eff. (HasExample res) => e (Sink eff res)
+  jsonRequest  :: forall req eff. (HasExample req) => e (Source eff (Either ServiceError req))
+  jsonResponse :: forall res eff. (HasExample res) => e (Sink eff res)
   optional     :: forall a. e a -> e (Maybe a)
   comments     :: String -> e Unit
 

--- a/src/REST/Endpoint.purs
+++ b/src/REST/Endpoint.purs
@@ -41,6 +41,7 @@ import Data.Foreign (Foreign, toForeign)
 import Data.Foreign.Class (class IsForeign)
 
 import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (EXCEPTION)
 
 import Data.List as L
 
@@ -83,7 +84,7 @@ class (AsForeign a) <= HasExample a where
 type Sink eff res = res -> Eff (http :: Node.HTTP | eff) Unit
 
 -- | A `Source` provides a request asynchronously.
-type Source eff req = (req -> Eff (http :: Node.HTTP | eff) Unit) -> Eff (http :: Node.HTTP | eff) Unit
+type Source eff req = (req -> Eff (http :: Node.HTTP | eff) Unit) -> Eff (http :: Node.HTTP, err :: EXCEPTION | eff) Unit
 
 -- | A service error - status code and message.
 data ServiceError = ServiceError Int String

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,11 +10,12 @@ import Data.String (toUpper)
 
 import Control.Apply ()
 import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Console (CONSOLE, log)
 
 import Node.HTTP        as Node
 
-import REST.Endpoint (comments, header, post, lit, response, get, Sink, ServiceError(..), class Endpoint, class AsForeign, class HasExample, sendResponse, Source)
+import REST.Endpoint (comments, header, post, lit, response, get, Sink, ServiceError(..), class Endpoint, class AsForeign, class HasExample, sendResponse, Source, jsonResponse, jsonRequest)
 import REST.Server (serve)
 import REST.Docs (serveDocs)
 
@@ -41,10 +42,10 @@ home = worker <$> (get *> response)
   where
   worker res = sendResponse res 200 "text/plain" "Hello, world!"
 
-echo :: forall e eff. (Endpoint e) => e (Eff (http :: Node.HTTP | eff) Unit)
+echo :: forall e eff. (Endpoint e) => e (Eff (http :: Node.HTTP, err :: EXCEPTION | eff) Unit)
 echo = worker <$> (docs *> post *> lit "echo" *> shoutHeader) <*> jsonRequest <*> jsonResponse <*> response
   where
-  worker :: String -> Source eff (Either ServiceError Echo) -> Sink eff Echo -> Node.Response -> Eff (http :: Node.HTTP | eff) Unit
+  worker :: String -> Source eff (Either ServiceError Echo) -> Sink eff Echo -> Node.Response -> Eff (http :: Node.HTTP, err :: EXCEPTION | eff) Unit
   worker shout source sink res = do
     source \e ->
       case e of

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,24 +2,24 @@ module Test.Main where
 
 import Prelude
 
-import Data.Maybe
-import Data.Either
-import Data.Foreign
-import Data.Foreign.Class
+import Data.Maybe (Maybe(..))
+import Data.Either (Either(..))
+import Data.Foreign (toForeign)
+import Data.Foreign.Class (class IsForeign, readProp)
 import Data.String (toUpper)
 
-import Control.Apply
-import Control.Monad.Eff
-import Control.Monad.Eff.Console
+import Control.Apply ()
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
 
-import qualified Node.HTTP        as Node
+import Node.HTTP        as Node
 
-import REST.Endpoint
-import REST.Server
-import REST.Docs
+import REST.Endpoint (comments, header, post, lit, response, get, Sink, ServiceError(..), class Endpoint, class AsForeign, class HasExample, sendResponse, Source)
+import REST.Server (serve)
+import REST.Docs (serveDocs)
 
-import qualified Text.Smolder.HTML                as H
-import qualified Text.Smolder.HTML.Attributes     as A
+import Text.Smolder.HTML                as H
+import Text.Smolder.HTML.Attributes     as A
 import Text.Smolder.Markup (Markup(), (!), text)
 
 data Echo = Echo String
@@ -41,18 +41,18 @@ home = worker <$> (get *> response)
   where
   worker res = sendResponse res 200 "text/plain" "Hello, world!"
 
-echo :: forall e eff. (Endpoint e) => e (Eff (http :: Node.HTTP | eff) Unit)
-echo = worker <$> (docs *> post *> lit "echo" *> shoutHeader) <*> jsonRequest <*> jsonResponse <*> response
-  where
-  worker :: String -> Source eff (Either ServiceError Echo) -> Sink eff Echo -> Node.Response -> Eff (http :: Node.HTTP | eff) Unit
-  worker shout source sink res = do
-    source \e ->
-      case e of
-        Left (ServiceError code msg) -> sendResponse res code "text/plain" msg
-        Right (Echo s) -> sink <<< Echo $
-          case shout of
-            "yes" -> toUpper s
-            _ -> s
+-- echo :: forall e eff. (Endpoint e) => e (Eff (http :: Node.HTTP | eff) Unit)
+-- echo = worker <$> (docs *> post *> lit "echo" *> shoutHeader) <*> response
+--   where
+--   worker :: String -> Source eff (Either ServiceError Echo) -> Sink eff Echo -> Node.Response -> Eff (http :: Node.HTTP | eff) Unit
+--   worker shout source sink res = do
+--     source \e ->
+--       case e of
+--         Left (ServiceError code msg) -> sendResponse res code "text/plain" msg
+--         Right (Echo s) -> sink <<< Echo $
+--           case shout of
+--             "yes" -> toUpper s
+--             _ -> s
 
   docs :: e Unit
   docs = comments "Echos the request body in the response body."
@@ -61,9 +61,9 @@ echo = worker <$> (docs *> post *> lit "echo" *> shoutHeader) <*> jsonRequest <*
   shoutHeader = header "X-Shout" "This header should be non-empty if the result should be capitalized."
 
 endpoints :: forall e eff. (Endpoint e) => Array (e (Eff (http :: Node.HTTP | eff) Unit))
-endpoints = [ home, echo ]
+endpoints = [ home ]
 
-template :: Markup -> Markup
+template :: forall a. Markup a -> Markup a
 template body = do
   H.html ! A.lang "en" $ do
     H.head $ do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -41,18 +41,18 @@ home = worker <$> (get *> response)
   where
   worker res = sendResponse res 200 "text/plain" "Hello, world!"
 
--- echo :: forall e eff. (Endpoint e) => e (Eff (http :: Node.HTTP | eff) Unit)
--- echo = worker <$> (docs *> post *> lit "echo" *> shoutHeader) <*> response
---   where
---   worker :: String -> Source eff (Either ServiceError Echo) -> Sink eff Echo -> Node.Response -> Eff (http :: Node.HTTP | eff) Unit
---   worker shout source sink res = do
---     source \e ->
---       case e of
---         Left (ServiceError code msg) -> sendResponse res code "text/plain" msg
---         Right (Echo s) -> sink <<< Echo $
---           case shout of
---             "yes" -> toUpper s
---             _ -> s
+echo :: forall e eff. (Endpoint e) => e (Eff (http :: Node.HTTP | eff) Unit)
+echo = worker <$> (docs *> post *> lit "echo" *> shoutHeader) <*> jsonRequest <*> jsonResponse <*> response
+  where
+  worker :: String -> Source eff (Either ServiceError Echo) -> Sink eff Echo -> Node.Response -> Eff (http :: Node.HTTP | eff) Unit
+  worker shout source sink res = do
+    source \e ->
+      case e of
+        Left (ServiceError code msg) -> sendResponse res code "text/plain" msg
+        Right (Echo s) -> sink <<< Echo $
+          case shout of
+            "yes" -> toUpper s
+            _ -> s
 
   docs :: e Unit
   docs = comments "Echos the request body in the response body."


### PR DESCRIPTION
I went through the codebase and updated the syntax and dependencies to work with the latest version of PureScript.  I think everything should work as before, but I did run into a problem rewriting the `jsonRequest` function for the `Endpoint Server` instance.  I get a type error on the Right case...

```
Node.onEnd requestStream do
  body <- unsafeRunRef $ readRef bodyRef
  case (runExcept $ readJSON body) of
    Right a -> respond (Right a)
    Left _ -> respond (Left (ServiceError 400 "Bad request"))
```

```
src/REST/Server.purs:121:26
Right a -> respond (Right a)
                ^^^^^^^^^^^^^^^^^
Could not match type
  Function
with type
  Eff
```

I'm not entirely sure how to fix that, but everything else seems to work.  When I comment out the code that uses `jsonRequest` and `jsonResponse`, I can start the server and hit the `home` endpoint in the browser.